### PR TITLE
Update env variable names for Postgres

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -28,7 +28,8 @@ Instalação e Uso
    git clone https://seu.git.repo/sistema-patrimonial.git
    cd sistema-patrimonial
    
-2. Crie o arquivo `.env` com as variáveis necessárias (`SECRET_KEY`, `DATABASE_URL`, etc.).  
+2. Crie o arquivo `.env` com as variáveis necessárias (`SECRET_KEY`, `POSTGRES_DB`,
+   `POSTGRES_USER`, `POSTGRES_PASSWORD`, `DB_HOST`, `DB_PORT`, etc.).
 3. Levante os serviços com Docker Compose:  
    bash
    docker-compose up --build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-gestao_utf8}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-123}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+  web:
+    image: python:3.12-slim
+    working_dir: /app
+    command: bash -c "pip install -r requirements.txt && python manage.py migrate && python manage.py runserver 0.0.0.0:8000"
+    volumes:
+      - .:/app
+    env_file:
+      - .env
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+volumes:
+  postgres_data:

--- a/gestao_patrimonial/settings.py
+++ b/gestao_patrimonial/settings.py
@@ -116,9 +116,9 @@ WSGI_APPLICATION = 'gestao_patrimonial.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': os.environ.get('DB_NAME', 'gestao_utf8'),
-        'USER': os.environ.get('DB_USER', 'postgres'),
-        'PASSWORD': os.environ.get('DB_PASSWORD', '123'),
+        'NAME': os.environ.get('POSTGRES_DB', 'gestao_utf8'),
+        'USER': os.environ.get('POSTGRES_USER', 'postgres'),
+        'PASSWORD': os.environ.get('POSTGRES_PASSWORD', '123'),
         'HOST': os.environ.get('DB_HOST', 'localhost'),
         'PORT': os.environ.get('DB_PORT', '5432'),
         'OPTIONS': {


### PR DESCRIPTION
## Summary
- standardize Postgres env variable names
- document required variables in README
- add example `docker-compose.yml`

## Testing
- `python manage.py check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68419376205c8323a12a8a875bc77028