### PR TITLE
Add production environment docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Exemplo de configuracao
+SECRET_KEY=your-secret-key
+DEBUG=False
+ALLOWED_HOSTS=yourdomain.com
+POSTGRES_DB=gestao_utf8
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=your_db_password
+DB_HOST=localhost
+DB_PORT=5432
+COSMOS_API_KEY=your-cosmos-api-key
+DJANGO_SUPERUSER_USERNAME=admin
+DJANGO_SUPERUSER_PASSWORD=admin
+DJANGO_SUPERUSER_EMAIL=admin@example.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+.Python
+env/
+venv/
+ENV/
+
+# Django stuff
+*.sqlite3
+/staticfiles/
+/media/
+
+# Local environment variables
+.env
+
+# VS Code
+.vscode/
+
+# Mac OS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Gestão Patrimonial
+
+Este repositório contém uma aplicação Django para controle patrimonial. O projeto pode ser executado localmente com Docker, mas também está preparado para implantação em produção.
+
+## Configuração
+
+1. Copie `.env.example` para `.env` e ajuste os valores.
+2. Defina `DEBUG=False` e preencha `ALLOWED_HOSTS` com o domínio desejado ao hospedar na internet.
+3. Execute `docker-compose up --build` para iniciar.
+
+Para mais detalhes consulte `core/README.md`.

--- a/core/README.md
+++ b/core/README.md
@@ -30,6 +30,9 @@ Instalação e Uso
    
 2. Crie o arquivo `.env` com as variáveis necessárias (`SECRET_KEY`, `POSTGRES_DB`,
    `POSTGRES_USER`, `POSTGRES_PASSWORD`, `DB_HOST`, `DB_PORT`, etc.).
+   - Para disponibilizar a aplicação na internet defina `DEBUG=False`,
+     preencha `ALLOWED_HOSTS` com o domínio ou IP de produção e
+     mantenha segredos como `COSMOS_API_KEY` nesse arquivo.
 3. Levante os serviços com Docker Compose:  
    bash
    docker-compose up --build

--- a/gestao_patrimonial/settings.py
+++ b/gestao_patrimonial/settings.py
@@ -172,4 +172,4 @@ AUTH_USER_MODEL = 'core.Usuario'
 # ------------------------------------------------------------------------------
 # Chave da API Cosmos (exemplo; mover para env em produção)
 # ------------------------------------------------------------------------------
-COSMOS_API_KEY = os.environ.get('COSMOS_API_KEY', '3fTpL-M47SqFLJ8qq1RAPg')
+COSMOS_API_KEY = os.environ.get('COSMOS_API_KEY', 'your-cosmos-api-key')

--- a/interface/controllers/views_backup.py
+++ b/interface/controllers/views_backup.py
@@ -9,6 +9,7 @@ from django.core.files.storage import FileSystemStorage
 from django.http import JsonResponse, HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
+from django.conf import settings
 from django.db.models.functions import TruncMonth
 from django.core.mail import send_mail
 from django.core.serializers.json import DjangoJSONEncoder
@@ -401,7 +402,7 @@ def deletar_produto(request, produto_id):
 def buscar_nome_produto_por_codigo(codigo_barras):
     url = f"https://api.cosmos.bluesoft.com.br/gtins/{codigo_barras}.json"
     headers = {
-        "X-Cosmos-Token": "3fTpL-M47SqFLJ8qq1RAPg",  # Substitua por seu token real
+        "X-Cosmos-Token": settings.COSMOS_API_KEY,
         "Content-Type": "application/json",
         "User-Agent": "Cosmos-API-Request"
     }


### PR DESCRIPTION
## Summary
- add `.gitignore` and `.env.example`
- document how to run in production
- patch default `COSMOS_API_KEY` placeholder
- read cosmos API key from settings in backup view

## Testing
- `python manage.py test` *(fails: connection refused)*
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_68419e74b3748323b9dcbb403d5b58cb